### PR TITLE
20201221 update

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
           ~/.cargo/.crates2.json
           ~/.cargo/bin
           ~/.cargo/registry
-        key: ${{ hashFiles('WORKSPACE', '.bazelrc', '.bazelversion', 'bazel/cargo/Cargo.lock') }}
+        key: ${{ hashFiles('WORKSPACE', '.bazelrc', '.bazelversion', 'bazel/cargo/Cargo.lock', 'bazel/dependencies.bzl', 'bazel/repositories.bzl') }}
 
     - name: Build (wasm32-unknown-unknown)
       run: bazelisk --bazelrc=/dev/null build --platforms=@io_bazel_rules_rust//rust/platform:wasm //...

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,8 @@ crate-type = ["cdylib"]
 name = "http_body"
 path = "examples/http_body.rs"
 crate-type = ["cdylib"]
+
+[[example]]
+name = "http_config"
+path = "examples/http_config.rs"
+crate-type = ["cdylib"]

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ upstream won't add or is undecided or unresponsive about.
 + [Extending Envoy with WASM and Rust](https://antweiss.com/blog/extending-envoy-with-wasm-and-rust/)
 + [Extending Istio with Rust and WebAssembly](https://blog.red-badger.com/extending-istio-with-rust-and-webassembly)
 
-# Updating dependencies
+## Updating dependencies
 
-When updating dependencies, you need to regenerate `BUILD` files to match updated `Cargo.toml`:
+When updating dependencies, you need to regenerate Bazel `BUILD` files to match updated `Cargo.toml`:
 ```
-cargo install cargo-raze --git https://github.com/google/cargo-raze --rev cb9f85d22b1c81cceb9acaf1fa4336c5fc4e6bff
+cargo install cargo-raze --version 0.7.0
 rm -rf bazel/cargo/
 cargo generate-lockfile
 cargo raze --output=bazel/cargo

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,22 +1,9 @@
 workspace(name = "proxy_wasm_rust_sdk")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@proxy_wasm_rust_sdk//bazel:repositories.bzl", "proxy_wasm_rust_sdk_repositories")
 
-http_archive(
-    name = "io_bazel_rules_rust",
-    sha256 = "17dbf791f4dab0fd4496ce5345af35e9ce2f6d011c1c8423436da517d019a3ea",
-    strip_prefix = "rules_rust-2f97db595b05b1ee8cc44bde5bdf03c00bd169fb",
-    url = "https://github.com/bazelbuild/rules_rust/archive/2f97db595b05b1ee8cc44bde5bdf03c00bd169fb.tar.gz",
-)
+proxy_wasm_rust_sdk_repositories()
 
-load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
+load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_dependencies")
 
-rust_repositories()
-
-load("@io_bazel_rules_rust//:workspace.bzl", "rust_workspace")
-
-rust_workspace()
-
-load("//bazel/cargo:crates.bzl", "raze_fetch_remote_crates")
-
-raze_fetch_remote_crates()
+proxy_wasm_rust_sdk_dependencies()

--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -1,0 +1,20 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
+load("@proxy_wasm_rust_sdk//bazel/cargo:crates.bzl", "raze_fetch_remote_crates")
+
+def proxy_wasm_rust_sdk_dependencies():
+    rust_repositories()
+    raze_fetch_remote_crates()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def proxy_wasm_rust_sdk_repositories():
+    http_archive(
+        name = "io_bazel_rules_rust",
+        sha256 = "5cb2fbcc3debebc7b68f5f66c1b7ef741bdcca87c70594de688d4518538c36c8",
+        strip_prefix = "rules_rust-aa7c6938cf1cc2973bc065c7532f89874bf09818",
+        url = "https://github.com/bazelbuild/rules_rust/archive/aa7c6938cf1cc2973bc065c7532f89874bf09818.tar.gz",
+    )

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -52,3 +52,15 @@ rust_binary(
         "//bazel/cargo:log",
     ],
 )
+
+rust_binary(
+    name = "http_config",
+    srcs = ["http_config.rs"],
+    crate_type = "cdylib",
+    edition = "2018",
+    out_binary = True,
+    deps = [
+        "//:proxy_wasm",
+        "//bazel/cargo:log",
+    ],
+)

--- a/examples/http_body.rs
+++ b/examples/http_body.rs
@@ -18,7 +18,21 @@ use proxy_wasm::types::*;
 #[no_mangle]
 pub fn _start() {
     proxy_wasm::set_log_level(LogLevel::Trace);
-    proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> { Box::new(HttpBody) });
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> { Box::new(HttpBodyRoot) });
+}
+
+struct HttpBodyRoot;
+
+impl Context for HttpBodyRoot {}
+
+impl RootContext for HttpBodyRoot {
+    fn get_type(&self) -> Option<ContextType> {
+        Some(ContextType::HttpContext)
+    }
+
+    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
+        Some(Box::new(HttpBody))
+    }
 }
 
 struct HttpBody;

--- a/examples/http_body.rs
+++ b/examples/http_body.rs
@@ -46,7 +46,7 @@ impl HttpContext for HttpBody {
         // Since we returned "Pause" previuously, this will return the whole body.
         if let Some(body_bytes) = self.get_http_response_body(0, body_size) {
             let body_str = String::from_utf8(body_bytes).unwrap();
-            if body_str.find("secret").is_some() {
+            if body_str.contains("secret") {
                 let new_body = format!("Original message body ({} bytes) redacted.", body_size);
                 self.set_http_response_body(0, body_size, &new_body.into_bytes());
             }

--- a/examples/http_config.rs
+++ b/examples/http_config.rs
@@ -1,0 +1,64 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+
+#[no_mangle]
+pub fn _start() {
+    proxy_wasm::set_log_level(LogLevel::Trace);
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> {
+        Box::new(HttpConfigHeaderRoot {
+            header_content: String::new(),
+        })
+    });
+}
+
+struct HttpConfigHeader {
+    header_content: String,
+}
+
+impl Context for HttpConfigHeader {}
+
+impl HttpContext for HttpConfigHeader {
+    fn on_http_response_headers(&mut self, _num_headers: usize) -> FilterHeadersStatus {
+        self.add_http_response_header("custom-header", self.header_content.as_str());
+        FilterHeadersStatus::Continue
+    }
+}
+
+struct HttpConfigHeaderRoot {
+    header_content: String,
+}
+
+impl Context for HttpConfigHeaderRoot {}
+
+impl RootContext for HttpConfigHeaderRoot {
+    fn on_configure(&mut self, _plugin_configuration_size: usize) -> bool {
+        if let Some(config_bytes) = self.get_configuration() {
+            self.header_content = String::from_utf8(config_bytes).unwrap()
+        }
+        true
+    }
+
+    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
+        Some(Box::new(HttpConfigHeader {
+            header_content: self.header_content.clone(),
+        }))
+    }
+
+    fn get_type(&self) -> Option<ContextType> {
+        Some(ContextType::HttpContext)
+    }
+}

--- a/examples/http_headers.rs
+++ b/examples/http_headers.rs
@@ -19,9 +19,23 @@ use proxy_wasm::types::*;
 #[no_mangle]
 pub fn _start() {
     proxy_wasm::set_log_level(LogLevel::Trace);
-    proxy_wasm::set_http_context(|context_id, _| -> Box<dyn HttpContext> {
-        Box::new(HttpHeaders { context_id })
-    });
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> { Box::new(HttpHeadersRoot) });
+}
+
+struct HttpHeadersRoot;
+
+impl Context for HttpHeadersRoot {}
+
+impl RootContext for HttpHeadersRoot {
+    fn get_type(&self) -> Option<ContextType> {
+        Some(ContextType::HttpContext)
+    }
+
+    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
+        Some(Box::new(HttpHeaders {
+            context_id: _context_id,
+        }))
+    }
 }
 
 struct HttpHeaders {

--- a/examples/http_headers.rs
+++ b/examples/http_headers.rs
@@ -31,10 +31,8 @@ impl RootContext for HttpHeadersRoot {
         Some(ContextType::HttpContext)
     }
 
-    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
-        Some(Box::new(HttpHeaders {
-            context_id: _context_id,
-        }))
+    fn create_http_context(&self, context_id: u32) -> Option<Box<dyn HttpContext>> {
+        Some(Box::new(HttpHeaders { context_id }))
     }
 }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -95,37 +95,6 @@ impl Dispatcher {
         }
     }
 
-    /// Lets the root context to create its child context.
-    fn create_child_context(&self, context_id: u32, root_context_id: u32) -> bool {
-        if !self.roots.borrow().contains_key(&root_context_id) {
-            panic!("invalid root_context_id")
-        }
-        if let Some(child_context) = self
-            .roots
-            .borrow_mut()
-            .get_mut(&root_context_id)
-            .and_then(|root| root.on_create_child_context(context_id))
-        {
-            if match child_context {
-                ChildContext::HttpContext(http_context) => self
-                    .http_streams
-                    .borrow_mut()
-                    .insert(context_id, http_context)
-                    .is_some(),
-                ChildContext::StreamContext(stream_context) => self
-                    .streams
-                    .borrow_mut()
-                    .insert(context_id, stream_context)
-                    .is_some(),
-            } {
-                panic!("duplicate context_id")
-            }
-            true
-        } else {
-            false
-        }
-    }
-
     fn create_stream_context(&self, context_id: u32, root_context_id: u32) {
         if !self.roots.borrow().contains_key(&root_context_id) {
             panic!("invalid root_context_id")
@@ -176,8 +145,6 @@ impl Dispatcher {
     fn on_create_context(&self, context_id: u32, root_context_id: u32) {
         if root_context_id == 0 {
             self.create_root_context(context_id)
-        } else if self.create_child_context(context_id, root_context_id) {
-            // root context created a child context by himself
         } else if self.new_http_stream.get().is_some() {
             self.create_http_context(context_id, root_context_id);
         } else if self.new_stream.get().is_some() {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -378,22 +378,24 @@ impl Dispatcher {
         body_size: usize,
         num_trailers: usize,
     ) {
-        if let Some(context_id) = self.callouts.borrow_mut().remove(&token_id) {
-            if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
-                self.active_id.set(context_id);
-                hostcalls::set_effective_context(context_id).unwrap();
-                http_stream.on_http_call_response(token_id, num_headers, body_size, num_trailers)
-            } else if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
-                self.active_id.set(context_id);
-                hostcalls::set_effective_context(context_id).unwrap();
-                stream.on_http_call_response(token_id, num_headers, body_size, num_trailers)
-            } else if let Some(root) = self.roots.borrow_mut().get_mut(&context_id) {
-                self.active_id.set(context_id);
-                hostcalls::set_effective_context(context_id).unwrap();
-                root.on_http_call_response(token_id, num_headers, body_size, num_trailers)
-            }
-        } else {
-            panic!("invalid token_id")
+        let context_id = self
+            .callouts
+            .borrow_mut()
+            .remove(&token_id)
+            .expect("invalid token_id");
+
+        if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
+            self.active_id.set(context_id);
+            hostcalls::set_effective_context(context_id).unwrap();
+            http_stream.on_http_call_response(token_id, num_headers, body_size, num_trailers)
+        } else if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
+            self.active_id.set(context_id);
+            hostcalls::set_effective_context(context_id).unwrap();
+            stream.on_http_call_response(token_id, num_headers, body_size, num_trailers)
+        } else if let Some(root) = self.roots.borrow_mut().get_mut(&context_id) {
+            self.active_id.set(context_id);
+            hostcalls::set_effective_context(context_id).unwrap();
+            root.on_http_call_response(token_id, num_headers, body_size, num_trailers)
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -121,6 +121,18 @@ pub trait RootContext: Context {
     fn on_queue_ready(&mut self, _queue_id: u32) {}
 
     fn on_log(&mut self) {}
+
+    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
+        None
+    }
+
+    fn create_stream_context(&self, _context_id: u32) -> Option<Box<dyn StreamContext>> {
+        None
+    }
+
+    fn get_type(&self) -> Option<ContextType> {
+        None
+    }
 }
 
 pub trait StreamContext: Context {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -99,12 +99,6 @@ pub trait Context {
     }
 }
 
-/// Represents a child context of the root context.
-pub enum ChildContext {
-    StreamContext(Box<dyn StreamContext>),
-    HttpContext(Box<dyn HttpContext>),
-}
-
 pub trait RootContext: Context {
     fn on_vm_start(&mut self, _vm_configuration_size: usize) -> bool {
         true
@@ -127,12 +121,6 @@ pub trait RootContext: Context {
     fn on_queue_ready(&mut self, _queue_id: u32) {}
 
     fn on_log(&mut self) {}
-
-    fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
-        // for the sake of compatibility with `set_http_context` and `set_stream_context` API,
-        // root context is not required to create its child context.
-        None
-    }
 }
 
 pub trait StreamContext: Context {

--- a/src/types.rs
+++ b/src/types.rs
@@ -70,6 +70,13 @@ pub enum FilterDataStatus {
 
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ContextType {
+    HttpContext = 0,
+    StreamContext = 1,
+}
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum BufferType {
     HttpRequestBody = 0,
     HttpResponseBody = 1,


### PR DESCRIPTION
This brings in a fix for nested HTTP calls and completely changes how child contexts are created. However, we'll revert back to `on_create_child_context` and then drop the other `set_*_context` functions because they are no longer needed.