### PR TITLE
Rework child contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ your cargo manifest's dependencies section:
 
 > proxy-wasm = { git = "https://github.com/3scale/proxy-wasm-rust-sdk", branch = "v0.1-stable", package = "proxy-wasm-3scale" }
 
+## Differences
+
+So far the main difference is that this fork does not support `set_*_context`
+calls, but instead requires the developer to implement `on_create_child_context`
+if they intend to create HTTP or Stream contexts.
+
+Additionally, this fork uses FilterStatus (and other similar types) instead of
+Action for returning status values back to Envoy. This is so we can avoid some
+bugs in filters by using values not exposed by Action. That said, at this
+moment such bugs might be already fixed and we could soon return to use Action.
+
 ## Contributing
 
 While the plan is to maintain this project as a lightweight fork on top of

--- a/examples/http_auth_random.rs
+++ b/examples/http_auth_random.rs
@@ -20,7 +20,17 @@ use std::time::Duration;
 #[no_mangle]
 pub fn _start() {
     proxy_wasm::set_log_level(LogLevel::Trace);
-    proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> { Box::new(HttpAuthRandom) });
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> { Box::new(HttpAuthRandomRoot) });
+}
+
+struct HttpAuthRandomRoot;
+
+impl Context for HttpAuthRandomRoot {}
+
+impl RootContext for HttpAuthRandomRoot {
+    fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
+        Some(ChildContext::HttpContext(Box::new(HttpAuthRandom)))
+    }
 }
 
 struct HttpAuthRandom;

--- a/examples/http_body.rs
+++ b/examples/http_body.rs
@@ -26,12 +26,8 @@ struct HttpBodyRoot;
 impl Context for HttpBodyRoot {}
 
 impl RootContext for HttpBodyRoot {
-    fn get_type(&self) -> Option<ContextType> {
-        Some(ContextType::HttpContext)
-    }
-
-    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
-        Some(Box::new(HttpBody))
+    fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
+        Some(ChildContext::HttpContext(Box::new(HttpBody)))
     }
 }
 

--- a/examples/http_config.rs
+++ b/examples/http_config.rs
@@ -52,13 +52,9 @@ impl RootContext for HttpConfigHeaderRoot {
         true
     }
 
-    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
-        Some(Box::new(HttpConfigHeader {
+    fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
+        Some(ChildContext::HttpContext(Box::new(HttpConfigHeader {
             header_content: self.header_content.clone(),
-        }))
-    }
-
-    fn get_type(&self) -> Option<ContextType> {
-        Some(ContextType::HttpContext)
+        })))
     }
 }

--- a/examples/http_headers.rs
+++ b/examples/http_headers.rs
@@ -27,12 +27,8 @@ struct HttpHeadersRoot;
 impl Context for HttpHeadersRoot {}
 
 impl RootContext for HttpHeadersRoot {
-    fn get_type(&self) -> Option<ContextType> {
-        Some(ContextType::HttpContext)
-    }
-
-    fn create_http_context(&self, context_id: u32) -> Option<Box<dyn HttpContext>> {
-        Some(Box::new(HttpHeaders { context_id }))
+    fn on_create_child_context(&mut self, context_id: u32) -> Option<ChildContext> {
+        Some(ChildContext::HttpContext(Box::new(HttpHeaders { context_id })))
     }
 }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -26,14 +26,6 @@ pub(crate) fn set_root_context(callback: NewRootContext) {
     DISPATCHER.with(|dispatcher| dispatcher.set_root_context(callback));
 }
 
-pub(crate) fn set_stream_context(callback: NewStreamContext) {
-    DISPATCHER.with(|dispatcher| dispatcher.set_stream_context(callback));
-}
-
-pub(crate) fn set_http_context(callback: NewHttpContext) {
-    DISPATCHER.with(|dispatcher| dispatcher.set_http_context(callback));
-}
-
 pub(crate) fn register_callout(token_id: u32) {
     DISPATCHER.with(|dispatcher| dispatcher.register_callout(token_id));
 }
@@ -46,9 +38,7 @@ impl RootContext for NoopRoot {}
 struct Dispatcher {
     new_root: Cell<Option<NewRootContext>>,
     roots: RefCell<HashMap<u32, Box<dyn RootContext>>>,
-    new_stream: Cell<Option<NewStreamContext>>,
     streams: RefCell<HashMap<u32, Box<dyn StreamContext>>>,
-    new_http_stream: Cell<Option<NewHttpContext>>,
     http_streams: RefCell<HashMap<u32, Box<dyn HttpContext>>>,
     active_id: Cell<u32>,
     callouts: RefCell<HashMap<u32, u32>>,
@@ -59,9 +49,7 @@ impl Dispatcher {
         Dispatcher {
             new_root: Cell::new(None),
             roots: RefCell::new(HashMap::new()),
-            new_stream: Cell::new(None),
             streams: RefCell::new(HashMap::new()),
-            new_http_stream: Cell::new(None),
             http_streams: RefCell::new(HashMap::new()),
             active_id: Cell::new(0),
             callouts: RefCell::new(HashMap::new()),
@@ -70,14 +58,6 @@ impl Dispatcher {
 
     fn set_root_context(&self, callback: NewRootContext) {
         self.new_root.set(Some(callback));
-    }
-
-    fn set_stream_context(&self, callback: NewStreamContext) {
-        self.new_stream.set(Some(callback));
-    }
-
-    fn set_http_context(&self, callback: NewHttpContext) {
-        self.new_http_stream.set(Some(callback));
     }
 
     fn register_callout(&self, token_id: u32) {
@@ -106,42 +86,22 @@ impl Dispatcher {
         }
     }
 
-    fn create_stream_context(&self, context_id: u32, root_context_id: u32) {
-        let new_context = match self.roots.borrow().get(&root_context_id) {
-            Some(root_context) => match self.new_stream.get() {
-                Some(f) => f(context_id, root_context_id),
-                None => match root_context.create_stream_context(context_id) {
-                    Some(stream_context) => stream_context,
-                    None => panic!("create_stream_context returned None"),
-                },
-            },
-            None => panic!("invalid root_context_id"),
-        };
+    fn register_stream_context(&self, context_id: u32, stream_ctx: Box<dyn StreamContext>) {
         if self
             .streams
             .borrow_mut()
-            .insert(context_id, new_context)
+            .insert(context_id, stream_ctx)
             .is_some()
         {
             panic!("duplicate context_id")
         }
     }
 
-    fn create_http_context(&self, context_id: u32, root_context_id: u32) {
-        let new_context = match self.roots.borrow().get(&root_context_id) {
-            Some(root_context) => match self.new_http_stream.get() {
-                Some(f) => f(context_id, root_context_id),
-                None => match root_context.create_http_context(context_id) {
-                    Some(stream_context) => stream_context,
-                    None => panic!("create_http_context returned None"),
-                },
-            },
-            None => panic!("invalid root_context_id"),
-        };
+    fn register_http_context(&self, context_id: u32, http_ctx: Box<dyn HttpContext>) {
         if self
             .http_streams
             .borrow_mut()
-            .insert(context_id, new_context)
+            .insert(context_id, http_ctx)
             .is_some()
         {
             panic!("duplicate context_id")
@@ -151,22 +111,21 @@ impl Dispatcher {
     fn on_create_context(&self, context_id: u32, root_context_id: u32) {
         if root_context_id == 0 {
             self.create_root_context(context_id);
-        } else if self.new_http_stream.get().is_some() {
-            self.create_http_context(context_id, root_context_id);
-        } else if self.new_stream.get().is_some() {
-            self.create_stream_context(context_id, root_context_id);
-        } else if let Some(root_context) = self.roots.borrow().get(&root_context_id) {
-            match root_context.get_type() {
-                Some(ContextType::HttpContext) => {
-                    self.create_http_context(context_id, root_context_id)
+            return;
+        }
+
+        if let Some(root_ctx) = self.roots.borrow_mut().get_mut(&root_context_id) {
+            match root_ctx.on_create_child_context(context_id) {
+                Some(ChildContext::HttpContext(http_ctx)) => {
+                    self.register_http_context(context_id, http_ctx)
                 }
-                Some(ContextType::StreamContext) => {
-                    self.create_stream_context(context_id, root_context_id)
+                Some(ChildContext::StreamContext(stream_ctx)) => {
+                    self.register_stream_context(context_id, stream_ctx)
                 }
-                None => panic!("missing ContextType on root_context"),
+                None => panic!("you must define on_create_child_context in your root context"),
             }
         } else {
-            panic!("invalid root_context_id and missing constructors");
+            panic!("invalid root_context_id {}", root_context_id);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,5 @@ pub fn set_root_context(callback: types::NewRootContext) {
     dispatcher::set_root_context(callback);
 }
 
-pub fn set_stream_context(callback: types::NewStreamContext) {
-    dispatcher::set_stream_context(callback);
-}
-
-pub fn set_http_context(callback: types::NewHttpContext) {
-    dispatcher::set_http_context(callback);
-}
-
 #[no_mangle]
 pub extern "C" fn proxy_abi_version_0_1_0() {}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -16,6 +16,11 @@ use crate::hostcalls;
 use crate::types::*;
 use std::time::{Duration, SystemTime};
 
+pub enum ChildContext {
+    StreamContext(Box<dyn StreamContext>),
+    HttpContext(Box<dyn HttpContext>),
+}
+
 pub trait Context {
     fn get_current_time(&self) -> SystemTime {
         hostcalls::get_current_time().unwrap()
@@ -122,15 +127,8 @@ pub trait RootContext: Context {
 
     fn on_log(&mut self) {}
 
-    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
-        None
-    }
-
-    fn create_stream_context(&self, _context_id: u32) -> Option<Box<dyn StreamContext>> {
-        None
-    }
-
-    fn get_type(&self) -> Option<ContextType> {
+    fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
+        // on_create_child_context _is required_ to create its child context
         None
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -70,13 +70,6 @@ pub enum FilterDataStatus {
 
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum ContextType {
-    HttpContext = 0,
-    StreamContext = 1,
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum BufferType {
     HttpRequestBody = 0,
     HttpResponseBody = 1,


### PR DESCRIPTION
This adds back support for `on_create_child_context` and removes other methods for performing the same task. This way we only allow filters to do this in a single way and in the process drop extra trait functions and a couple fields in the dispatcher struct.